### PR TITLE
chore: sync core info files from libretro-super

### DIFF
--- a/app/src/main/assets/core_info/supermodel_libretro.info
+++ b/app/src/main/assets/core_info/supermodel_libretro.info
@@ -1,0 +1,34 @@
+# Software Information
+display_name = "Sega - Model 3 (Supermodel)"
+authors = "The Supermodel Team"
+corename = "Supermodel"
+supported_extensions = "zip|chd|7z"
+license = "GPLv3"
+categories = "Emulator"
+display_version = "v0.1.0-beta"
+
+# Hardware Information
+manufacturer = "Sega"
+systemname = "Model 3"
+systemid = "model3"
+
+# Database Information
+database = "Sega - Model 3"
+
+# Libretro Features
+savestate = "true"
+savestate_features = "serialized"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "true"
+core_options = "true"
+core_options_version = "2.0"
+hw_render = "true"
+required_hw_api = "OpenGL >= 2.1|OpenGL ES >= 3.0"
+needs_fullpath = "true"
+is_experimental = "false"
+
+# Description & Notes
+description = "A port of the Supermodel emulator to the Libretro API, enabling high-fidelity Sega Model 3 arcade emulation."
+notes = "(!) L.A. Machineguns and other gun games require calibration in the Test Menu (Service/Test buttons). | Supports Lightgun and Force Feedback (Rumble)."

--- a/app/src/main/assets/core_info/tia_libretro.info
+++ b/app/src/main/assets/core_info/tia_libretro.info
@@ -1,0 +1,32 @@
+display_name = "Atari - 2600 (Tia)"
+authors = "Eric Warmenhoven"
+supported_extensions = "a26|bin"
+corename = "Tia"
+license = "GPLv2+"
+permissions = ""
+display_version = "26"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Atari"
+systemname = "Atari 2600"
+systemid = "atari_2600"
+
+# Libretro Features
+database = "Atari - 2600"
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "deterministic"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "2.0"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "false"
+disk_control = "false"
+is_experimental = "false"
+
+description = "A libretro core for the Atari 2600. Cycle-accurate 6507 / TIA / 6532 emulation with region detection, a broad cartridge-mapper set , and joystick, paddle, driving-controller, and keypad support."

--- a/app/src/main/assets/core_info/virtualjaguar_libretro.info
+++ b/app/src/main/assets/core_info/virtualjaguar_libretro.info
@@ -1,11 +1,11 @@
 # Software Information
 display_name = "Atari - Jaguar (Virtual Jaguar)"
-authors = "David Raingeard|Shamus"
+authors = "David Raingeard|Shamus|Joseph Mattiello"
 supported_extensions = "j64|jag|rom|abs|cof|bin|prg"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v2.1.0"
+display_version = "v2.2.0"
 categories = "Emulator"
 
 # Hardware Information
@@ -16,8 +16,9 @@ systemid = "atari_jaguar"
 # Libretro Features
 supports_no_game = "false"
 database = "Atari - Jaguar"
-savestate = "false"
-cheats = "false"
+savestate = "true"
+savestate_features = "2"
+cheats = "true"
 input_descriptors = "true"
 memory_descriptors = "true"
 libretro_saves = "true"
@@ -28,4 +29,4 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
-description = "A port of the Virtual Jaguar emulator, which itself is based on Potato Emulation, to libretro. This core has known issues with a number of popular games, but it still represents the state of the art for open source Atari Jaguar emulation at the time of this writing. It is quite demanding but also includes a core option--Fast Blitter--that forces the use of an older, less compatible but faster blitter, though some games will not work properly with this option enabled."
+description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and a Fast Blitter core option is available that trades some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."


### PR DESCRIPTION
Automated sync of `app/src/main/assets/core_info/` from [libretro/libretro-super](https://github.com/libretro/libretro-super/tree/master/dist/info).

- Added: 0
- Removed: 0
- Modified: 1

Review the diff to confirm no cores we rely on have changed their `database` field in a way that breaks `CoreInfoRepository.tagToDatabases` mapping.