### PR TITLE
chore: sync core info files from libretro-super

### DIFF
--- a/app/src/main/assets/core_info/mednafen_saturn_libretro.info
+++ b/app/src/main/assets/core_info/mednafen_saturn_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - Saturn (Beetle Saturn)"
 authors = "Mednafen Team"
-supported_extensions = "ccd|chd|cue|toc|m3u"
+supported_extensions = "ccd|chd|cue|toc|m3u|zip"
 corename = "Beetle Saturn"
 
 # Hardware Information


### PR DESCRIPTION
Automated sync of `app/src/main/assets/core_info/` from [libretro/libretro-super](https://github.com/libretro/libretro-super/tree/master/dist/info).

- Added: 0
- Removed: 0
- Modified: 1

Review the diff to confirm no cores we rely on have changed their `database` field in a way that breaks `CoreInfoRepository.tagToDatabases` mapping.