### PR TITLE
chore: sync core info files from libretro-super

### DIFF
--- a/app/src/main/assets/core_info/mednafen_psx_hw_libretro.info
+++ b/app/src/main/assets/core_info/mednafen_psx_hw_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sony - PlayStation (Beetle PSX HW)"
 authors = "Mednafen Team"
-supported_extensions = "cue|toc|m3u|ccd|exe|pbp|chd"
+supported_extensions = "cue|toc|m3u|ccd|exe|pbp|chd|bin"
 corename = "Beetle PSX HW"
 
 # Hardware Information

--- a/app/src/main/assets/core_info/mednafen_psx_libretro.info
+++ b/app/src/main/assets/core_info/mednafen_psx_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sony - PlayStation (Beetle PSX)"
 authors = "Mednafen Team"
-supported_extensions = "cue|toc|m3u|ccd|exe|pbp|chd"
+supported_extensions = "cue|toc|m3u|ccd|exe|pbp|chd|bin"
 corename = "Beetle PSX"
 
 # Hardware Information

--- a/app/src/main/assets/core_info/native32emu_libretro.info
+++ b/app/src/main/assets/core_info/native32emu_libretro.info
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Native32 (Native32Emu)"
+authors = "Aloys"
+supported_extensions = "smf|sgm|ssl"
+corename = "native32emu"
+categories = "Emulator"
+license = "BSD-3-Clause"
+permissions = ""
+display_version = "0.1.0"
+
+# Hardware Information
+manufacturer = "Sunplus"
+systemname = "Native32"
+systemid = "native32"
+
+# Libretro Features
+database = "Native32"
+supports_no_game = "false"
+firmware_count = 0
+savestate = "false"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "false"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "true"
+
+description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content. Audio is currently limited to RAW PCM (MP3 music is not yet played); save states and core options are not implemented."

--- a/app/src/main/assets/core_info/nuance_libretro.info
+++ b/app/src/main/assets/core_info/nuance_libretro.info
@@ -1,0 +1,47 @@
+# Software Information
+display_name = "VM Labs - NUON (Nuance)"
+authors = "Mike Perry|Carsten Waechter|WizzardSK"
+supported_extensions = "run|cof|nuon|cd|iso|img"
+corename = "Nuance"
+categories = "Emulator"
+license = "Non-commercial"
+permissions = ""
+display_version = "0.6.7"
+
+# Hardware Information
+manufacturer = "VM Labs"
+systemname = "NUON"
+systemid = "nuon"
+
+# Libretro Features
+database = "VM Labs - NUON"
+supports_no_game = "false"
+hw_render = "true"
+required_hw_api = "OpenGL >= 2.1"
+needs_fullpath = "true"
+disk_control = "false"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "false"
+core_options_version = "null"
+load_subsystem = "false"
+is_experimental = "true"
+
+# Firmware / BIOS
+firmware_count = 3
+firmware0_desc = "bios.cof (NUON main BIOS, shipped with the emulator)"
+firmware0_path = "nuance/bios.cof"
+firmware0_opt = "false"
+firmware1_desc = "minibios.cof (NUON minibios for MPEs 0-2)"
+firmware1_path = "nuance/minibios.cof"
+firmware1_opt = "false"
+firmware2_desc = "minibiosX.cof (NUON extended minibios)"
+firmware2_path = "nuance/minibiosX.cof"
+firmware2_opt = "false"
+notes = "The bios.cof / minibios.cof / minibiosX.cof files are clean-room emulator stubs that ship with the Nuance source distribution (NOT proprietary firmware dumps). They must be copied into <system>/nuance/ before loading a game."
+
+description = "Nuance is a NUON (VM Labs) emulator. NUON was a media-processing architecture embedded in a handful of DVD players (Samsung DVD-N501/N2000, Toshiba SD-2300, RCA DRC-480N) and used to ship a small number of games (Ballistic, Tempest 3000, Merlin Racing, Iron Soldier 3, Freefall 3050 A.D., Space Invaders XL, etc.) on standard DVD discs. The Linux/libretro port adds an OpenGL render path, miniaudio output, FUSE/ISO9660 disc reading, and an asmjit-based 64-bit JIT on top of the original Windows codebase. Currently x86_64-only and considered experimental. Games are loaded from raw ISO/BIN/CUE disc images or from individual .run/.cof program files dumped out of the disc filesystem."

--- a/app/src/main/assets/core_info/prboom_libretro.info
+++ b/app/src/main/assets/core_info/prboom_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Doom (PrBoom)"
 authors = "Florian Schulze"
-supported_extensions = "wad|iwad|pwad"
+supported_extensions = "wad|iwad|pwad|pk3"
 corename = "PrBoom"
 license = "GPLv2"
 permissions = ""


### PR DESCRIPTION
Automated sync of `app/src/main/assets/core_info/` from [libretro/libretro-super](https://github.com/libretro/libretro-super/tree/master/dist/info).

- Added: 0
- Removed: 0
- Modified: 3

Review the diff to confirm no cores we rely on have changed their `database` field in a way that breaks `CoreInfoRepository.tagToDatabases` mapping.