### PR TITLE
delfino: carry the multi-disc file list in the launch params

### DIFF
--- a/app/src/main/java/dev/cannoli/scorza/launcher/LaunchManager.kt
+++ b/app/src/main/java/dev/cannoli/scorza/launcher/LaunchManager.kt
@@ -21,6 +21,7 @@ import dev.cannoli.scorza.model.Rom
 import dev.cannoli.scorza.settings.SettingsRepository
 import dev.cannoli.scorza.ui.screens.DialogState
 import dev.cannoli.scorza.util.ArchiveExtractor
+import dev.cannoli.scorza.util.parseM3uDiscPaths
 import java.io.File
 import java.io.IOException
 import java.security.MessageDigest
@@ -496,6 +497,8 @@ class LaunchManager(
             colors = igm.colors,
             displaySettings = igm.displaySettings,
             inputMapping = igm.inputMapping,
+            discPaths = rom.path.takeIf { it.extension.equals("m3u", ignoreCase = true) }
+                ?.let(::parseM3uDiscPaths) ?: emptyList(),
         )
     }
 

--- a/app/src/main/java/dev/cannoli/scorza/util/M3uDiscPaths.kt
+++ b/app/src/main/java/dev/cannoli/scorza/util/M3uDiscPaths.kt
@@ -1,0 +1,11 @@
+package dev.cannoli.scorza.util
+
+import java.io.File
+
+/** Parses an m3u playlist into the ordered absolute paths of the disc files it references. */
+fun parseM3uDiscPaths(m3u: File): List<String> = runCatching {
+    m3u.readLines()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() && !it.startsWith("#") }
+        .map { entry -> File(m3u.parentFile, entry).absolutePath }
+}.getOrDefault(emptyList())

--- a/app/src/test/java/dev/cannoli/scorza/util/M3uDiscPathsTest.kt
+++ b/app/src/test/java/dev/cannoli/scorza/util/M3uDiscPathsTest.kt
@@ -1,0 +1,42 @@
+package dev.cannoli.scorza.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class M3uDiscPathsTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    @Test
+    fun `parseM3uDiscPaths returns ordered absolute disc paths`() {
+        val dir = tmp.newFolder()
+        val m3u = File(dir, "game.m3u").apply {
+            writeText("# comment\ngame (Disc 1).iso\ngame (Disc 2).iso\n")
+        }
+        assertEquals(
+            listOf(File(dir, "game (Disc 1).iso").absolutePath, File(dir, "game (Disc 2).iso").absolutePath),
+            parseM3uDiscPaths(m3u),
+        )
+    }
+
+    @Test
+    fun `parseM3uDiscPaths skips blank lines`() {
+        val dir = tmp.newFolder()
+        val m3u = File(dir, "game.m3u").apply {
+            writeText("game (Disc 1).iso\n\n  \ngame (Disc 2).iso\n")
+        }
+        assertEquals(
+            listOf(File(dir, "game (Disc 1).iso").absolutePath, File(dir, "game (Disc 2).iso").absolutePath),
+            parseM3uDiscPaths(m3u),
+        )
+    }
+
+    @Test
+    fun `parseM3uDiscPaths returns empty list for unreadable file`() {
+        val missing = File(tmp.newFolder(), "missing.m3u")
+        assertEquals(emptyList<String>(), parseM3uDiscPaths(missing))
+    }
+}

--- a/cannoli-igm/build.gradle.kts
+++ b/cannoli-igm/build.gradle.kts
@@ -43,4 +43,5 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.material3)
     testImplementation(libs.junit)
+    testImplementation("org.robolectric:robolectric:4.13")
 }

--- a/cannoli-igm/src/main/java/dev/cannoli/igm/DelfinoLaunchParams.kt
+++ b/cannoli-igm/src/main/java/dev/cannoli/igm/DelfinoLaunchParams.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.os.Parcel
 import android.os.Parcelable
 
-const val DELFINO_PROTOCOL_VERSION = 1
+const val DELFINO_PROTOCOL_VERSION = 2
 
 data class DelfinoLaunchParams(
     val romPath: String,
@@ -19,6 +19,7 @@ data class DelfinoLaunchParams(
     val colors: IgmColors?,
     val displaySettings: IgmDisplaySettings?,
     val inputMapping: IgmInputMapping?,
+    val discPaths: List<String> = emptyList(),
 ) : Parcelable {
 
     fun resolvedSavesDir(): String = savesDir ?: "$cannoliRoot/Saves"
@@ -46,6 +47,7 @@ data class DelfinoLaunchParams(
         dest.writeParcelable(colors, flags)
         dest.writeParcelable(displaySettings, flags)
         dest.writeParcelable(inputMapping, flags)
+        dest.writeStringList(discPaths)
     }
 
     companion object {
@@ -53,7 +55,8 @@ data class DelfinoLaunchParams(
         const val EXTRA_PROTOCOL = "DELFINO_PROTOCOL"
 
         fun readFromIntent(intent: Intent): DelfinoLaunchParams? {
-            if (intent.getIntExtra(EXTRA_PROTOCOL, -1) != DELFINO_PROTOCOL_VERSION) return null
+            val version = intent.getIntExtra(EXTRA_PROTOCOL, -1)
+            if (version != DELFINO_PROTOCOL_VERSION && version != 1) return null
             @Suppress("DEPRECATION")
             return intent.getParcelableExtra(EXTRA)
         }
@@ -62,7 +65,7 @@ data class DelfinoLaunchParams(
         val CREATOR = object : Parcelable.Creator<DelfinoLaunchParams> {
             override fun createFromParcel(p: Parcel): DelfinoLaunchParams {
                 val version = p.readInt()
-                if (version != DELFINO_PROTOCOL_VERSION) {
+                if (version != DELFINO_PROTOCOL_VERSION && version != 1) {
                     throw ProtocolMismatchException(version, DELFINO_PROTOCOL_VERSION)
                 }
                 val romPath = p.readString()!!
@@ -82,9 +85,11 @@ data class DelfinoLaunchParams(
                 @Suppress("DEPRECATION")
                 val inputMapping =
                     p.readParcelable<IgmInputMapping>(IgmInputMapping::class.java.classLoader)
+                val discPaths = if (version >= 2) (p.createStringArrayList() ?: emptyList()) else emptyList()
                 return DelfinoLaunchParams(
                     romPath, cannoliRoot, savesDir, saveStatesDir, biosDir, userDir,
                     gameTitle, platformTag, igmTriggerKeycodes, colors, displaySettings, inputMapping,
+                    discPaths,
                 )
             }
 

--- a/cannoli-igm/src/test/java/dev/cannoli/igm/DelfinoLaunchParamsTest.kt
+++ b/cannoli-igm/src/test/java/dev/cannoli/igm/DelfinoLaunchParamsTest.kt
@@ -1,0 +1,69 @@
+package dev.cannoli.igm
+
+import android.os.Parcel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class DelfinoLaunchParamsTest {
+
+    private fun sampleParams(discPaths: List<String> = emptyList()) = DelfinoLaunchParams(
+        romPath = "/sd/Cannoli/Roms/GC/Baten Kaitos.m3u",
+        cannoliRoot = "/sd/Cannoli",
+        savesDir = null,
+        saveStatesDir = null,
+        biosDir = null,
+        userDir = null,
+        gameTitle = "Baten Kaitos",
+        platformTag = "GC",
+        igmTriggerKeycodes = listOf(4, 109),
+        colors = null,
+        displaySettings = null,
+        inputMapping = null,
+        discPaths = discPaths,
+    )
+
+    @Test
+    fun `disc paths survive the parcel round trip`() {
+        val params = sampleParams(discPaths = listOf("/a/disc1.iso", "/a/disc2.iso"))
+        val parcel = Parcel.obtain()
+        params.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+        val restored = DelfinoLaunchParams.CREATOR.createFromParcel(parcel)
+        parcel.recycle()
+        assertEquals(listOf("/a/disc1.iso", "/a/disc2.iso"), restored.discPaths)
+    }
+
+    @Test
+    fun `disc paths default to empty`() {
+        assertEquals(emptyList<String>(), sampleParams().discPaths)
+    }
+
+    @Test
+    fun `reading a v1 parcel defaults disc paths to empty`() {
+        // Hand-writes the pre-discPaths wire format: same fields, no trailing disc list.
+        val parcel = Parcel.obtain()
+        parcel.writeInt(1)
+        parcel.writeString("/sd/Cannoli/Roms/GC/Baten Kaitos.m3u")
+        parcel.writeString("/sd/Cannoli")
+        parcel.writeString(null)
+        parcel.writeString(null)
+        parcel.writeString(null)
+        parcel.writeString(null)
+        parcel.writeString("Baten Kaitos")
+        parcel.writeString("GC")
+        parcel.writeIntArray(intArrayOf(4, 109))
+        parcel.writeParcelable(null, 0)
+        parcel.writeParcelable(null, 0)
+        parcel.writeParcelable(null, 0)
+        parcel.setDataPosition(0)
+        val restored = DelfinoLaunchParams.CREATOR.createFromParcel(parcel)
+        parcel.recycle()
+        assertEquals(emptyList<String>(), restored.discPaths)
+        assertEquals("Baten Kaitos", restored.gameTitle)
+    }
+}


### PR DESCRIPTION
DelfinoLaunchParams gains discPaths (protocol v2); LaunchManager populates it from the launched m3u for multi-disc roms, empty otherwise.