### PR TITLE
chore: sync core info files from libretro-super

### DIFF
--- a/app/src/main/assets/core_info/fuse_libretro.info
+++ b/app/src/main/assets/core_info/fuse_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sinclair - ZX Spectrum (Fuse)"
 authors = "Team Fuse"
-supported_extensions = "tzx|tap|z80|rzx|scl|trd|dsk|dck|sna|szx|zip"
+supported_extensions = "tzx|tap|z80|rzx|scl|trd|dsk|dck|sna|szx|zip|ipf"
 corename = "Fuse"
 categories = "Emulator"
 license = "GPLv3"

--- a/app/src/main/assets/core_info/virtualjaguar_libretro.info
+++ b/app/src/main/assets/core_info/virtualjaguar_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "j64|jag|rom|abs|cof|bin|prg"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v2.2.0"
+display_version = "v2.3.2"
 categories = "Emulator"
 
 # Hardware Information
@@ -29,4 +29,4 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
-description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and a Fast Blitter core option is available that trades some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."
+description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."


### PR DESCRIPTION
Automated sync of `app/src/main/assets/core_info/` from [libretro/libretro-super](https://github.com/libretro/libretro-super/tree/master/dist/info).

- Added: 0
- Removed: 0
- Modified: 2

Review the diff to confirm no cores we rely on have changed their `database` field in a way that breaks `CoreInfoRepository.tagToDatabases` mapping.